### PR TITLE
feat: add unit price and subtotal to payment metadata

### DIFF
--- a/routes/payment.js
+++ b/routes/payment.js
@@ -20,11 +20,15 @@ router.post("/stripe-checkout", async (req, res) => {
         adminId: adminId || "default",
         address: JSON.stringify(address || {}),
         products: JSON.stringify(
-          items.map(i => ({
-            name: i.price_data.product_data.name,
-            quantity: i.quantity,
-            price: i.price_data.unit_amount / 100
-          }))
+          items.map(i => {
+            const unitPrice = i.price_data.unit_amount / 100;
+            return {
+              name: i.price_data.product_data.name,
+              quantity: i.quantity,
+              unitPrice,
+              subtotal: i.quantity * unitPrice,
+            };
+          })
         )
       },
     });

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -30,7 +30,12 @@ router.post("/stripe-webhook", async (req, res) => {
 
       let products = [];
       if (session.metadata.products) {
-        products = JSON.parse(session.metadata.products);
+        products = JSON.parse(session.metadata.products).map(p => ({
+          name: p.name,
+          quantity: p.quantity,
+          unitPrice: p.unitPrice ?? p.price ?? 0,
+          subtotal: p.subtotal ?? p.quantity * (p.unitPrice ?? p.price ?? 0),
+        }));
         console.log("📡 DB conectado:", mongoose.connection.name);
         console.log("📦 Salvando pedido:", {
           email: session.metadata.email,


### PR DESCRIPTION
## Summary
- include unitPrice and subtotal when sending products to Stripe checkout
- normalize webhook product data to ensure unitPrice and subtotal are present

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb761089c832fa530184c52ef39fa