### PR TITLE
feat: sync Stripe orders via cron script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Crie um arquivo `.env` na raiz do projeto e configure as seguintes variáveis:
 
 ```env
 PORT=3000
-STRIPE_KEY=sua_chave_stripe
+STRIPE_SECRET_KEY=sua_chave_stripe
+MONGO_URI=sua_string_conexao_mongo
 STRIPE_WEBHOOK_SECRET=seu_webhook_secret
 DOMAIN=https://seu_dominio
 AWS_ACCESS_KEY_ID=sua_chave_aws
@@ -62,6 +63,22 @@ npm start
 ```
 
 O servidor estará disponível em `http://localhost:3000`.
+
+## Sincronização de Pedidos com Stripe
+
+Use o script `scripts/syncStripeOrders.js` para sincronizar pedidos do Stripe com o banco de dados.
+
+Execute manualmente:
+
+```
+node scripts/syncStripeOrders.js
+```
+
+Para agendar com cron (exemplo rodando diariamente à meia-noite):
+
+```
+0 0 * * * node /caminho/para/projeto/scripts/syncStripeOrders.js >> /var/log/stripe_sync.log 2>&1
+```
 
 ## Contribuição
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "prod": "node server.js"
+    "prod": "node server.js",
+    "sync:orders": "node scripts/syncStripeOrders.js"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/syncStripeOrders.js
+++ b/scripts/syncStripeOrders.js
@@ -1,0 +1,73 @@
+import Stripe from "stripe";
+import "dotenv/config";
+import connectMongo from "../services/mongo.js";
+import Order from "../models/Order.js";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+const PAGE_LIMIT = 100;
+
+async function syncStripeOrders() {
+  try {
+    await connectMongo();
+
+    let startingAfter;
+    let hasMore = true;
+    let processed = 0;
+
+    while (hasMore) {
+      const params = {
+        limit: PAGE_LIMIT,
+        expand: ["data.line_items"],
+      };
+      if (startingAfter) {
+        params.starting_after = startingAfter;
+      }
+
+      const sessions = await stripe.checkout.sessions.list(params);
+
+      for (const session of sessions.data) {
+        const products = (session.line_items?.data || []).map((item) => ({
+          name: item.description,
+          quantity: item.quantity,
+          unitPrice: item.price?.unit_amount
+            ? item.price.unit_amount / 100
+            : 0,
+          subtotal: item.amount_total ? item.amount_total / 100 : 0,
+        }));
+
+        const orderData = {
+          email: session.customer_details?.email || session.metadata?.email,
+          adminId: session.metadata?.adminId,
+          address: session.customer_details?.address || {},
+          products,
+          total: session.amount_total / 100,
+          status: session.payment_status,
+          stripeSessionId: session.id,
+          testMode: !session.livemode,
+        };
+
+        await Order.findOneAndUpdate(
+          { stripeSessionId: session.id },
+          orderData,
+          { upsert: true, new: true }
+        );
+      }
+
+      processed += sessions.data.length;
+      console.log(`Processed ${processed} sessions`);
+
+      if (sessions.has_more) {
+        startingAfter = sessions.data[sessions.data.length - 1].id;
+      }
+      hasMore = sessions.has_more;
+    }
+
+    console.log("Sync completed");
+    process.exit(0);
+  } catch (err) {
+    console.error("Failed to sync orders:", err);
+    process.exit(1);
+  }
+}
+
+syncStripeOrders();


### PR DESCRIPTION
## Summary
- add `scripts/syncStripeOrders.js` to import Stripe checkout sessions, upsert orders, and handle pagination
- document env vars and cron scheduling for Stripe order sync
- expose npm script `sync:orders`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdc46513ac832fbbe5fcfb62aec730